### PR TITLE
fix(controllers): get rid of type support error

### DIFF
--- a/backend/collections/admin.collections.http
+++ b/backend/collections/admin.collections.http
@@ -20,7 +20,7 @@ POST http://localhost:4000/v1/auth/login/admin
 Content-Type: application/json
 
 {
-    "userNameOrEmail":"sirlance",
+    "userNameOrEmail":"arthure",
     "password":"@Lance25"
 }
 

--- a/backend/package.json
+++ b/backend/package.json
@@ -28,7 +28,12 @@
         "mysql2": "^3.14.1",
         "nodemon": "^3.1.10",
         "supertest": "^7.1.3",
-        "ts-jest": "^29.4.0",
         "uuid": "^11.1.0"
+    },
+    "devDependencies": {
+        "@types/jest": "^30.0.0",
+        "jest": "^30.0.4",
+        "ts-jest": "^29.4.0",
+        "typescript": "^5.8.3"
     }
 }

--- a/backend/pnpm-lock.yaml
+++ b/backend/pnpm-lock.yaml
@@ -50,12 +50,22 @@ importers:
       supertest:
         specifier: ^7.1.3
         version: 7.1.3
-      ts-jest:
-        specifier: ^29.4.0
-        version: 29.4.0(@babel/core@7.28.0)(@jest/transform@30.0.4)(@jest/types@30.0.1)(babel-jest@30.0.4(@babel/core@7.28.0))(jest-util@30.0.2)(jest@30.0.4(@types/node@24.0.11))(typescript@5.8.3)
       uuid:
         specifier: ^11.1.0
         version: 11.1.0
+    devDependencies:
+      '@types/jest':
+        specifier: ^30.0.0
+        version: 30.0.0
+      jest:
+        specifier: ^30.0.4
+        version: 30.0.4(@types/node@24.0.11)
+      ts-jest:
+        specifier: ^29.4.0
+        version: 29.4.0(@babel/core@7.28.0)(@jest/transform@30.0.4)(@jest/types@30.0.1)(babel-jest@30.0.4(@babel/core@7.28.0))(jest-util@30.0.2)(jest@30.0.4(@types/node@24.0.11))(typescript@5.8.3)
+      typescript:
+        specifier: ^5.8.3
+        version: 5.8.3
 
 packages:
 
@@ -433,6 +443,9 @@ packages:
 
   '@types/istanbul-reports@3.0.4':
     resolution: {integrity: sha512-pk2B1NWalF9toCRu6gjBzR69syFjP4Od8WRAX+0mmf9lAjCRicLOWc+ZrxZHx/0XRjotgkF9t6iaMJ+aXcOdZQ==}
+
+  '@types/jest@30.0.0':
+    resolution: {integrity: sha512-XTYugzhuwqWjws0CVz8QpM36+T+Dz5mTEBKhNs/esGLnCIlGdRy+Dq78NRjd7ls7r8BC8ZRMOrKlkO1hU0JOwA==}
 
   '@types/methods@1.1.4':
     resolution: {integrity: sha512-ymXWVrDiCxTBE3+RIrrP533E70eA+9qu7zdWoHuOmGujkYtzf4HQF96b8nwHLqhuf4ykX61IGRIB38CC6/sImQ==}
@@ -2432,6 +2445,11 @@ snapshots:
   '@types/istanbul-reports@3.0.4':
     dependencies:
       '@types/istanbul-lib-report': 3.0.3
+
+  '@types/jest@30.0.0':
+    dependencies:
+      expect: 30.0.4
+      pretty-format: 30.0.2
 
   '@types/methods@1.1.4': {}
 

--- a/backend/src/api-v1/controllers/admin.controllers.ts
+++ b/backend/src/api-v1/controllers/admin.controllers.ts
@@ -117,10 +117,12 @@ export async function adminLogin(request: Request, response: Response) {
 
       // if no error in email validation
       const connection = await pool.getConnection();
-      const [rows] = await connection.query(`CALL getUserByNameOrEmail(?)`, [
-        userNameOrEmail,
-      ]);
-      const users = rows[0] as Users[]; //runs despite error from LSP
+      //HACK: prevents type support error
+      const [rows]: any = await connection.query(
+        `CALL getUserByNameOrEmail(?)`,
+        [userNameOrEmail],
+      );
+      const users = rows[0] as Users[];
       connection.release();
 
       //users exists
@@ -186,10 +188,12 @@ export async function adminLogin(request: Request, response: Response) {
 
       // if no error in username validation
       const connection = await pool.getConnection();
-      const [rows] = await connection.query(`CALL getUserByNameOrEmail(?)`, [
-        userNameOrEmail,
-      ]);
-      const users = rows[0] as Users[]; //runs despite error from LSP
+      //HACK: any helps prevent type support error
+      const [rows]: any = await connection.query(
+        `CALL getUserByNameOrEmail(?)`,
+        [userNameOrEmail],
+      );
+      const users = rows[0] as Users[];
       connection.release();
 
       //users exists

--- a/backend/src/api-v1/controllers/loan.controllers.ts
+++ b/backend/src/api-v1/controllers/loan.controllers.ts
@@ -39,19 +39,19 @@ export async function applyLoan(request: Request, response: Response) {
     }
     //if no validation error
     const connection = await pool.getConnection();
-    const [rows] = await connection.execute(`CALL getUserById(?);`, [user_id]);
-    const user = rows[0] as Users[]; //runs despite LSP error
+    const [rows]:any = await connection.execute(`CALL getUserById(?);`, [user_id]);
+    const user = rows[0] as Users[];
     connection.release();
 
     if (user.length > 0) {
       //ensure user status is active
       if (user[0].user_status == "active") {
         // ensure no pending loans
-        const [results] = await connection.execute(
+        const [results]:any = await connection.execute(
           `CALL getUserLoansById(?);`,
           [user_id],
         );
-        const loans = results[0] as Loans[]; //runs despite LSP error
+        const loans = results[0] as Loans[];
         connection.release();
 
         //check if user has pending loans
@@ -73,7 +73,7 @@ export async function applyLoan(request: Request, response: Response) {
               });
             } else {
               // else if none is pending
-              const [rows] = await connection.execute(
+              const [rows]:any = await connection.execute(
                 `CALL addLoan(?,?,?,?,?,?,?,?);`,
                 [
                   id,
@@ -86,7 +86,7 @@ export async function applyLoan(request: Request, response: Response) {
                   guarantor_details,
                 ],
               );
-              const user_loan = rows[0] as Loans[]; // runs despite LSP error
+              const user_loan = rows[0] as Loans[];
               connection.release();
 
               return response.status(201).json({
@@ -106,7 +106,7 @@ export async function applyLoan(request: Request, response: Response) {
         }
 
         //else issue loan
-        const [rows] = await connection.execute(
+        const [rows]:any = await connection.execute(
           `CALL addLoan(?,?,?,?,?,?,?,?);`,
           [
             id,
@@ -119,7 +119,7 @@ export async function applyLoan(request: Request, response: Response) {
             guarantor_details,
           ],
         );
-        const user_loan = rows[0] as Loans[]; // runs despite LSP error
+        const user_loan = rows[0] as Loans[];
         connection.release();
 
         return response.status(201).json({
@@ -176,14 +176,14 @@ export async function getLoans(request: Request, response: Response) {
 
   try {
     const connection = await pool.getConnection();
-    const [rows] = await connection.execute(`CALL getAllLoans();`);
+    const [rows]:any = await connection.execute(`CALL getAllLoans();`);
     connection.release();
     const loans = rows[0] as Loans[];
 
     if (loans.length > 0) {
-      const [results] = await connection.execute(`CALL detailedLoans();`);
+      const [results]:any = await connection.execute(`CALL detailedLoans();`);
       connection.release();
-      const detailed_loans = results[0] as Loans[]; //runs despite error warning
+      const detailed_loans = results[0] as Loans[];
             console.log(detailed_loans)
 
       return response.status(200).json({

--- a/backend/src/api-v1/controllers/member.controllers.ts
+++ b/backend/src/api-v1/controllers/member.controllers.ts
@@ -43,8 +43,8 @@ export async function createMember(request: Request, response: Response) {
 
     // if no validation errors
     const connection = await pool.getConnection();
-    const [rows] = await connection.query(`CALL getUserById(?)`, [admin_id]);
-    const admin_user = rows[0] as Users[]; //runs despite LSP error
+    const [rows]:any = await connection.query(`CALL getUserById(?)`, [admin_id]);
+    const admin_user = rows[0] as Users[];
 
     if (admin_user[0].user_role == "admin") {
       // hash the user password
@@ -113,7 +113,7 @@ export async function getMembers(request: Request, response: Response) {
    */
   try {
     const connection = await pool.getConnection();
-    const [rows] = await connection.execute(`CALL getAllUsers();`);
+    const [rows]:any = await connection.execute(`CALL getAllUsers();`);
     const users = rows[0] as Users[];
     connection.release();
 
@@ -156,12 +156,12 @@ export async function activateMember(
   const { user_id } = request.body;
   try {
     const connection = await pool.getConnection();
-    const [rows] = await connection.execute(`CALL getUserById(?);`, [admin_id]);
+    const [rows]:any = await connection.execute(`CALL getUserById(?);`, [admin_id]);
     const admin_user = rows[0] as Users[];
     connection.release();
 
     if (admin_user[0].user_role == "admin") {
-      const [results] = await connection.execute(`CALL getInactiveUsersById(?);`, [
+      const [results]:any = await connection.execute(`CALL getInactiveUsersById(?);`, [
         user_id,
       ]);
       const user_to_activate = results[0] as Users[];
@@ -169,7 +169,7 @@ export async function activateMember(
 
       // if user_to_activate exists
       if (user_to_activate.length > 0) {
-        const [results] = await connection.execute(
+        await connection.execute(
           `CALL activateUserById(?);`,
           [user_id],
         );

--- a/backend/src/api-v1/controllers/microfinance.controllers.ts
+++ b/backend/src/api-v1/controllers/microfinance.controllers.ts
@@ -78,7 +78,7 @@ export async function getMicrofinances(request: Request, response: Response) {
    */
   try {
     const connection = await pool.getConnection();
-    const [rows] = await connection.execute(`CALL getAllMicrofinances();`);
+    const [rows]:any = await connection.execute(`CALL getAllMicrofinances();`);
     const microfinances = rows[0] as Microfinances[]; //runs despite LSP
     connection.release();
 


### PR DESCRIPTION
My rows column had not being strongly typed. Gave them a temporary type of any to get rid of runtime error that appeared on all endpoints. This makes the console cleaner when running.

Also installed jest and its types to prevent the error on the basic test. Unsure how it had run earlier, but since i had installed the unistaleld it, it might have been stored in cache or sth.

TODO: dicover the real type of rows from querying the db and use that instead of any